### PR TITLE
Run gvim testing in windows by building from sources

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+#       os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest]
     steps:
       - name: Detect latest Vim's release
         run: |
@@ -50,16 +51,34 @@ jobs:
           Rename-Item -Path vim* -NewName vim
           $bindir = (Get-Item -Path vim/src).FullName
 
+          "BINDIR=$bindir" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
           "TESTDIR=$bindir/testdir" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
+
+          # Enter build dir
+          pushd $bindir
 
           if ($IsWindows)
           {
-            # Windows world: use precompiled binaries
-            Invoke-WebRequest -OutFile gvim.zip `
-                              -Uri https://github.com/vim/vim-win32-installer/releases/download/v$Env:RELEASE_VERSION/gvim_${Env:RELEASE_VERSION}_x64.zip
-            Expand-Archive -Path gvim.zip -DestinationPath . && rm gvim.zip
-            $vimdir = Get-Item -Path vim/vim*/vim.exe | Split-Path -Parent
-            Move-Item -Path $vimdir/* -Destination $bindir -Force
+            # Windows world: use precompiled binaries ... unless you need gVim ... build from sources
+            
+            # Set up development environment
+            $vswhere = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+            & $vswhere -find **/Microsoft.VisualStudio.DevShell.dll | Import-Module
+            Enter-VsDevShell -SetDefaultWindowTitle -InstallPath (& $vswhere -property installationPath) `
+                             -StartInPath $bindir -DevCmdArguments '/arch=x64 /host_arch=x64'
+            # Build matching environment tools (x64)
+            nmake -f Make_mvc.mak GUI=yes VIMDLL=yes CPU=AMD64 PLATFORMS=x64 DEBUG=yes USE_MP=NO USE_MSVCRT=yes
+
+            # For debug builds redirect to debug binaries
+            if (Test-Path -Path .\vimd.exe)
+            {
+              New-Item -ItemType SymbolicLink -Path .\vim.exe -Target .\vimd.exe
+            }
+
+            if (Test-Path -Path .\gvimd.exe)
+            {
+              New-Item -ItemType SymbolicLink -Path .\gvim.exe -Target .\gvimd.exe
+            }
           }
           else
           {
@@ -73,13 +92,14 @@ jobs:
               sudo apt-get install -y libx11-dev libxt-dev libxpm-dev libgtk2.0-dev libncurses-dev
             }
 
-            gi ./vim*/src | pushd
             ./configure --prefix=/tmp/workplace --enable-gui=auto
             # Get-Content -Path ./auto/config.mk
             # Get-Content -Path ./auto/config.log
             make
-            popd
           }
+
+          # Leaving build dir
+          popd
 
           # local
           $Env:PATH = "$bindir$([system.io.path]::PathSeparator)$Env:PATH"
@@ -88,8 +108,14 @@ jobs:
 
       - name: Check vim binaries
         run: |
-          # gcm vim | select Source
           vim --version
+
+          if (gcm gvim -ErrorAction SilentlyContinue)
+          {
+            $version = New-TemporaryFile 
+            gvim -c "redir! > $version | version | redir END | q!"
+            Get-Content -Path $version
+          }
 
       - name: Checkout-install SetPwsh
         uses: actions/checkout@v5
@@ -170,13 +196,8 @@ jobs:
             Remove-Item messages
           }
 
-          # Github Hosted Windows runner is headless
-          # unlike linux this cannot be workaround with a virtual display
-          $gui_available = -not $IsWindows -or $Env:RUNNER_ENVIRONMENT -ne "github-hosted"
-
           # check GUI binary availability and headless environment
-          if ( $gui_available -and (vim --version |
-               Select-String -Pattern 'with GTK. GUI|GUI/console') -ne $null )
+          if (vim --version | Select-String -Pattern 'with GTK. GUI|GUI/console')
           {
             Write-Host "Executing tests: $make $makefile $gui test_plugin_setpwsh"
             & $make @makefile @gui test_plugin_setpwsh

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,8 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-#       os: [windows-latest, ubuntu-latest, macos-latest]
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Detect latest Vim's release
         run: |
@@ -37,20 +36,34 @@ jobs:
           Write-Host "Latest Vim release is $release"
           "RELEASE_VERSION=$release" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
 
+      - name: Checkout-install SetPwsh
+        uses: actions/checkout@v5
+        with:
+          path: workplace/vim/runtime/pack/SetPwsh
+
       - name: Install Vim
         run: |
           $basedir = Get-Location
-          "BASEDIR=$basedir" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
 
-          New-Item -Type Directory -Path workplace | pushd
+          pushd workplace
 
+          # Download Vim sources
           Invoke-WebRequest -Uri https://github.com/vim/vim/archive/refs/tags/v$Env:RELEASE_VERSION.zip `
                             -OutFile vim.zip
 
-          Expand-Archive -Path vim.zip -DestinationPath . && Remove-Item vim.zip
-          Rename-Item -Path vim* -NewName vim
-          $bindir = (Get-Item -Path vim/src).FullName
+          # Unpack Vim sources && merge SetPwsh into
+          Expand-Archive -Path vim.zip -DestinationPath .
+          Remove-Item vim.zip
 
+          $vimdir = Get-Item -Path vim-*
+          Move-Item -Path vim/runtime/pack/SetPwsh -Destination $vimdir/runtime/pack
+          Remove-Item -Recurse -Force vim/runtime
+          Move-Item -Path $vimdir/* -Destination vim
+          rmdir $vimdir
+
+          # Set helpful environment variables
+          $bindir = (Get-Item -Path vim/src).FullName
+          "BASEDIR=$basedir" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
           "BINDIR=$bindir" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
           "TESTDIR=$bindir/testdir" | Out-File -Path $Env:GITHUB_ENV -Encoding OEM -Append
 
@@ -60,14 +73,23 @@ jobs:
           if ($IsWindows)
           {
             # Windows world: use precompiled binaries ... unless you need gVim ... build from sources
-            
+
+            # Fix Makefile to use clang-cl
+            Get-Content ../runtime/pack/SetPwsh/.github/workflows/vim_mvc_clang.patch | patch -d .. -p1
+
             # Set up development environment
             $vswhere = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
             & $vswhere -find **/Microsoft.VisualStudio.DevShell.dll | Import-Module
             Enter-VsDevShell -SetDefaultWindowTitle -InstallPath (& $vswhere -property installationPath) `
                              -StartInPath $bindir -DevCmdArguments '/arch=x64 /host_arch=x64'
+
+            # Decide to use cl or clang-cl
+            # $CC = "clang-cl"
+            $CC = "cl" # MSVC compiler seems to be faster in this case
+
             # Build matching environment tools (x64)
-            nmake -f Make_mvc.mak GUI=yes VIMDLL=yes CPU=AMD64 PLATFORMS=x64 DEBUG=yes USE_MP=NO USE_MSVCRT=yes
+            nmake -f Make_mvc.mak CC=$CC GUI=yes VIMDLL=yes CPU=AMD64 PLATFORMS=x64 `
+                                  DEBUG=yes USE_MP=NO USE_MSVCRT=yes
 
             # For debug builds redirect to debug binaries
             if (Test-Path -Path .\vimd.exe)
@@ -112,15 +134,10 @@ jobs:
 
           if (gcm gvim -ErrorAction SilentlyContinue)
           {
-            $version = New-TemporaryFile 
+            $version = New-TemporaryFile
             gvim -c "redir! > $version | version | redir END | q!"
             Get-Content -Path $version
           }
-
-      - name: Checkout-install SetPwsh
-        uses: actions/checkout@v5
-        with:
-          path: workplace/vim/runtime/pack/SetPwsh
 
       - name: Move tests to the test folder
         run: |
@@ -152,8 +169,8 @@ jobs:
         timeout-minutes: 5
         run: |
           # Hint plugin location to the tests
-          $Env:SETPWSH_RUNTIMEDIR = "$Env:BASEDIR/workplace/vim/runtime" 
-         
+          $Env:SETPWSH_RUNTIMEDIR = "$Env:BASEDIR/workplace/vim/runtime"
+
           # Prepare envioronment
           if ($IsWindows)
           {

--- a/.github/workflows/vim_mvc_clang.patch
+++ b/.github/workflows/vim_mvc_clang.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Make_mvc.mak b/src/Make_mvc.mak
+index a59b083e7..adf03e918 100644
+--- a/src/Make_mvc.mak
++++ b/src/Make_mvc.mak
+@@ -814,7 +814,11 @@ EXECFLAGS =
+ EXELIBC = $(LIBC)
+ ! ELSE
+ EXECFLAGS = -DUSE_OWNSTARTUP /GS-
++!  IFDEF NODEBUG
+ EXELIBC =
++!  ELSE
++EXELIBC = ucrtd.lib
++!  ENDIF
+ ! ENDIF
+ !ELSE
+ OBJ = $(OBJ) $(OUTDIR)\os_w32exe.obj $(OUTDIR)\vim.res


### PR DESCRIPTION
The binaries provided by the [win32 installer](https://github.com/vim/vim-win32-installer) releases hang on gvim.
It seems building from sources workarounds this issue.
I tried to speed up building using `clang-cl` but was ineffectual (probably due to warning reporting).