### PR TITLE
Alignment with vim's patch 9.2.0006

### DIFF
--- a/start/setpwsh/doc/setpwsh.txt
+++ b/start/setpwsh/doc/setpwsh.txt
@@ -512,6 +512,7 @@ may slow down startup is disabled by default.
 ==============================================================================
 7. History						       *setpwsh-history*
 
+	v1.1.8: Feb 16, 2026    * (Miguel Barro) Adapt to vim patch 9.2.0006
 	v1.1.6: Oct 21, 2025    * (Miguel Barro) Fix BOM for powershell.
 				  Fix v:shell_error. CI testing.
 	v1.1.5: May 16, 2025	* (Miguel Barro) Fix pwsh as dotnet tool on linux.

--- a/start/setpwsh/plugin/setpwsh.vim
+++ b/start/setpwsh/plugin/setpwsh.vim
@@ -5,7 +5,7 @@ if exists('g:loaded_setpwsh') || &cp
   finish
 endif
 
-let g:loaded_setpwsh = '1.1.1' " version number
+let g:loaded_setpwsh = '1.1.8' " version number
 
 " dummy version replaced by the actual ones if possible
 command -nargs=* SetPwsh
@@ -81,7 +81,11 @@ function s:cspwsh(...)
     return ["Desktop", "FtpFromWsl", "SshFromWsl", "NoViewer"]
 endfunction
 
-let s:script_dir = expand('<sfile>:p:h') .. '/../scripts/'
+if has("patch-9.2.0006")
+    let s:script_dir = expand('<sfile>:p:h') .. '/../scripts/'
+else
+    let s:script_dir = expand('<sfile>:p:h') .. '/../scripts/pre_9.2.0006'
+endif
 
 if has('win32')
 

--- a/start/setpwsh/scripts/gvim_pwsh_proxy.ps1
+++ b/start/setpwsh/scripts/gvim_pwsh_proxy.ps1
@@ -50,9 +50,11 @@ try
     $cmd = $cmd.SubString(0, $cmd.Length - $offset)
 
     # Check for redirection
-    if ($cmd -match '>(\S*)$')
+    if ($cmd -match '\((.*)\) >(\S*)$')
     {
-        $redir_file = $matches[1]
+        # remove inner parentheses to avoid error (see patch 9.2.0006)
+        $cmd = '& {{ {0} }} >{1}' -f $matches[1], $matches[2]
+        $redir_file = $matches[2]
     }
     else
     {

--- a/start/setpwsh/scripts/pre_9.2.0006/ftp.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/ftp.ps1
@@ -1,0 +1,46 @@
+# ftp.ps1
+# Precondition:
+# :let g:netrw_ftp_cmd="$PSScriptRoot/ftp.ps1"
+# Several comments:
+#  + Note we must execute all statements pipe in on the very same ftp instance. That's the reason why we gathered in the variable $pipeline all the inputs.
+#  + The ftp binary is expecting a file like stdin thus we must join the string[] into a single array with newline
+#    characters.
+#  + Without the quit statement ftp triggers and error.
+
+begin
+{
+    $pipeline = @()
+}
+process
+{
+    if ($_)
+    {
+        $text = $_
+        $pipeline += $text | Select-String -Pattern "([`"']?)[a-zA-Z]:[\w\s\./\\]*\1" -AllMatches |
+             Select -ExpandProperty Matches | Sort-Object -Property Index -Descending |
+             ForEach-Object { $newtext = $text } {
+                if ($_.Value[0] -match "[`"']")
+                {
+                    $wslpath = wsl -e wslpath (Invoke-Expression $_.Value)
+                    $newtext = $newtext.Remove($_.index+1, $_.Length-2).Insert($_.index+1, $wslpath)
+                }
+                else
+                {
+                    $wslpath = wsl -e wslpath $_.Value
+                    $newtext = $newtext.Remove($_.index, $_.Length).Insert($_.index, $wslpath)
+                }
+
+             } { $newtext }
+    }
+}
+end
+{
+    if ($pipeline)
+    {
+        ($pipeline + 'quit ') -join "`n" | wsl -e ftp -p $args
+    }
+    else
+    {
+        wsl -e ftp -p $args
+    }
+}

--- a/start/setpwsh/scripts/pre_9.2.0006/gvim_pwsh_proxy.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/gvim_pwsh_proxy.ps1
@@ -43,22 +43,18 @@ try
         $indec = '$PSStyle.OutputRendering = "PlainText";'
     }
 
-    # Extract the command to execute
-    if ($cmdline -match '\(& { (.*) }.*\)' -or $cmdline -match '\((.*)\)$')
-    {
-        $cmd = $matches[1]
-    }
-    else
-    {
-        throw "Unexpected command line: $cmdline"
-    }
+    $outdec = "2>&1 | Out-String -Stream"
+    $filter = $cmdline -match "\(\(.*\)\)$"
+    if ($filter) { $offset = 2 } else { $offset = 1 } # desktop version lacks ternary operator ?:
+    $cmd = $cmdline.SubString($cmdline.IndexOf("(") + $offset)
+    $cmd = $cmd.SubString(0, $cmd.Length - $offset)
 
     # Check for redirection
-    if ($cmdline -match '>(\S*)\)$')
+    if ($cmd -match '\((.*)\) >(\S*)$')
     {
-        # avoid multiple expression error (see patch 9.2.0006)
-        $redir_file = $matches[1]
-        $cmd = '& {{ {0} }} >{1}' -f $cmd, $redir_file
+        # remove inner parentheses to avoid error (see patch 9.2.0006)
+        $cmd = '& {{ {0} }} >{1}' -f $matches[1], $matches[2]
+        $redir_file = $matches[2]
     }
     else
     {

--- a/start/setpwsh/scripts/pre_9.2.0006/openprg_pwsh_proxy.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/openprg_pwsh_proxy.ps1
@@ -1,0 +1,26 @@
+# openprg_pwsh_proxy.ps1
+# Script that allows:
+# • common vim9 utils → g:Openprg
+# • netrw plugin → g:netrw_browsex_viewer 
+# to open files in the associated program according to Windows OS criteria.
+# It is equivalent to ShellExecute function in Windows API.
+
+if (!$IsWindows)
+{
+    throw "This script is intended for Windows only."
+}
+
+if ($PSEdition -eq "Desktop")
+{
+    $cmdline = [System.Environment]::CommandLine
+}
+else
+{
+    $cmdline = (Get-Process -Pid $pid).CommandLine
+}
+
+if ($cmdline -match "$($MyInvocation.MyCommand.Name)\s+(`"?)(.*)\1")
+{
+    $filename = $matches[2]
+    Start-Process -Verb Open -FilePath (Get-Item -Path $filename)
+}

--- a/start/setpwsh/scripts/pre_9.2.0006/scp.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/scp.ps1
@@ -1,0 +1,2 @@
+. $PSScriptRoot/wsl.ps1
+Invoke-WSL scp -q @Args

--- a/start/setpwsh/scripts/pre_9.2.0006/ssh.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/ssh.ps1
@@ -1,0 +1,2 @@
+. $PSScriptRoot/wsl.ps1
+Invoke-WSL ssh -q @Args

--- a/start/setpwsh/scripts/pre_9.2.0006/vim_pwsh_linux_proxy.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/vim_pwsh_linux_proxy.ps1
@@ -64,19 +64,15 @@ try
                ForEach-Object { $res = $cmd } { $res = $res.Remove($_.Index, $_.Length) }
 
         $is_pipe = $res -match '\$_\b'
-        $is_input = $res -match '\$input\b'
+        # $is_input = $res -match '\$input\b'
 
         if ($is_pipe)
         { # execute expression per-line
             $cmd = $cat + " | % { " + $cmd + " } " + $redir
         }
-        elseif ($is_input)
-        {
-            $cmd = $cat + " | & { " + $cmd + " } " + $redir
-        }
         else
         { # use script object to enable $input and avoid redirection errors (see patch 9.2.0006)
-            $cmd = $cat + " | & { `$input | " + $cmd + " } " + $redir
+            $cmd = $cat + " | & { " + $cmd + " } " + $redir
         }
 
         $ErrorActionPreference = "Stop"
@@ -84,7 +80,7 @@ try
     }
     else
     {
-        if ($cmdline -match "\(& {(?<cmd>.*)}(?<redir>>.*)\)$")
+        if ($cmdline -match "\((?<cmd>.*)(?<redir>>.*)\)$")
         {
             $cmd = $matches.cmd
             $redir = $matches.redir

--- a/start/setpwsh/scripts/pre_9.2.0006/vim_pwsh_proxy.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/vim_pwsh_proxy.ps1
@@ -1,7 +1,7 @@
-# vim_pwsh_linux_proxy.ps1
+# vim_pwsh_proxy.ps1
 # Expects:
-#   set shell=pwsh
-#   let &shellcmdflag="-NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File vim_pwsh_linux_proxy.ps1 
+#   set shell=powershell (or set shell=pwsh)
+#   let &shellcmdflag="-NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File \"" . s:auxshellscriptname . '"' 
 #   set shellquote=
 #   set shellxquote=(
 #   set shellredir=>%s
@@ -13,11 +13,13 @@ try
     {
         "ascii" {'$OutputEncoding = New-Object System.Text.ASCIIEncoding;'}
         "utf7" {'$OutputEncoding = New-Object System.Text.UTF7Encoding;'}
-        "utf32" {'$OutputEncoding = New-Object System.Text.UTF32Encoding  (,$false);'}
-        "unicode" {'$OutputEncoding = New-Object System.Text.UnicodeEncoding  (,$false);'}
+        "utf32" {'$OutputEncoding = New-Object System.Text.UTF32Encoding (,$false);'}
+        "unicode" {'$OutputEncoding = New-Object System.Text.UnicodeEncoding (,$false);'}
         default
         {
-            $Env:setpwsh_encoding = "utf8NoBOM"
+            if ($PsVersionTable.PSEdition -eq "Core")
+            { $Env:setpwsh_encoding = "utf8NoBOM" } else
+            { $Env:setpwsh_encoding = "utf8" }
             '$OutputEncoding = New-Object System.Text.UTF8Encoding $false;'
         }
     }
@@ -28,29 +30,16 @@ try
 
     Invoke-Expression -Command $encoding
 
-    # Check if running under dotnet
-    if ([System.Environment]::ProcessPath -match "dotnet")
+    # Retrieve command line
+    $proc = Get-Process -Pid $pid
+
+    if ($PSEdition -eq "Desktop")
     {
-        # Retrieve command line. Don't use Get-Process because somehow quotes disappear.
         $cmdline = [System.Environment]::CommandLine
-
-        if ($cmdline -match '(?<pwsh_arg>.*/pwsh.dll)')
-        {
-            $pwsh_cmd = "dotnet"
-            $pwsh_arg = $matches.pwsh_arg
-
-            # dotnet spawns another process where the commandline quotes may be removed.
-            # Stick to the vim's call commandline
-            $cmdline = (Get-Process -id $pid).Parent.CommandLine
-        }
     }
-
-    # For snap or binaries version use $args
-    if ($pwsh_cmd -eq $null)
+    else
     {
-        $pwsh_cmd = "pwsh"
-        $pwsh_arg = $null
-        $cmdline = "$args"
+        $cmdline = $proc.CommandLine
     }
 
     if ($cmdline -match "\(& {(?<cat>.*) \| & (?<cmd>.*)}(?<redir>.*)\)$")
@@ -64,19 +53,15 @@ try
                ForEach-Object { $res = $cmd } { $res = $res.Remove($_.Index, $_.Length) }
 
         $is_pipe = $res -match '\$_\b'
-        $is_input = $res -match '\$input\b'
+        # $is_input = $res -match '\$input\b'
 
         if ($is_pipe)
         { # execute expression per-line
             $cmd = $cat + " | % { " + $cmd + " } " + $redir
         }
-        elseif ($is_input)
-        {
-            $cmd = $cat + " | & { " + $cmd + " } " + $redir
-        }
         else
         { # use script object to enable $input and avoid redirection errors (see patch 9.2.0006)
-            $cmd = $cat + " | & { `$input | " + $cmd + " } " + $redir
+            $cmd = $cat + " | & { " + $cmd + " } " + $redir
         }
 
         $ErrorActionPreference = "Stop"
@@ -84,7 +69,7 @@ try
     }
     else
     {
-        if ($cmdline -match "\(& {(?<cmd>.*)}(?<redir>>.*)\)$")
+        if ($cmdline -match "\((?<cmd>.*)(?<redir> >.*)\)$")
         {
             $cmd = $matches.cmd
             $redir = $matches.redir
@@ -107,7 +92,6 @@ try
         if ($redir)
         {
             # allow multiple expressions (see patch 9.2.0006)
-            # redirection prevents error propagation
             $cmd = "& { `$ErrorActionPreference = 'Stop'; try { $cmd } catch { exit 1 }" 
             $cmd += '; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }}'
             $cmd += $redir
@@ -115,7 +99,31 @@ try
 
         # allow stdin forwarding under binary demand
         $b64_cmd = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($encoding + $cmd))
-        & $pwsh_cmd $pwsh_arg -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand $b64_cmd
+        & $proc.ProcessName -NoLogo -NoProfile -ExecutionPolicy Bypass `
+                            -NonInteractive -EncodedCommand $b64_cmd
+
+    }
+
+    # Unlike powershell core, BOM emission on redirection cannot be disabled for Desktop edition.
+    if ($PsVersionTable.PSEdition -eq "Desktop" -and $redir -ne $null)
+    {
+        # Remove BOM
+        # retrieve redirection file
+        $file = $redir -replace '^\s*>+\s*', ''
+        if (Test-Path -Path $file)
+        {
+            $BOM = @(0xef, 0xbb, 0xbf, 0xff, 0xfe, 0x00, 0x2b, 0x2f, 0x76)
+            $content = Get-Content -Path $file -Raw -Encoding Byte
+            if ($content)
+            {
+                # identify BOM
+                $Length = 0
+                $content[0..3] | ForEach-Object { if ($_ -in $BOM) { $Length++ } }
+                # ignore it
+                $content | Select-Object -Skip $Length |
+                    Set-Content -Path $file -Encoding Byte
+            }
+        }         
     }
 
     # propagate error level
@@ -123,6 +131,5 @@ try
 }
 catch
 {
-    $_.ToString()
-    exit 1
+    Write-Error $_.ToString()
 }

--- a/start/setpwsh/scripts/pre_9.2.0006/wsl.ps1
+++ b/start/setpwsh/scripts/pre_9.2.0006/wsl.ps1
@@ -1,0 +1,17 @@
+function Invoke-WSL
+{   
+    # Translate paths
+    $wslargs = @()
+        $args | ForEach-Object {
+            if( $_ -match "^[A-Z]:.*" )
+            {
+                $wslargs += wsl -e wslpath $_
+            }
+            else
+            {
+                $wslargs += $_
+            }
+        }
+
+    wsl --exec @wslargs 
+}

--- a/start/setpwsh/scripts/vim_pwsh_linux_proxy.ps1
+++ b/start/setpwsh/scripts/vim_pwsh_linux_proxy.ps1
@@ -64,19 +64,15 @@ try
                ForEach-Object { $res = $cmd } { $res = $res.Remove($_.Index, $_.Length) }
 
         $is_pipe = $res -match '\$_\b'
-        $is_input = $res -match '\$input\b'
+        # $is_input = $res -match '\$input\b'
 
         if ($is_pipe)
         { # execute expression per-line
             $cmd = $cat + " | % { " + $cmd + " } " + $redir
         }
-        elseif ($is_input)
-        { # use script object to enable $input
-            $cmd = $cat + " | & { " + $cmd + " } " + $redir
-        }
         else
-        { # send in bulk
-            $cmd = $cat + " | " + $cmd + " " + $redir
+        { # use script object to enable $input and avoid redirection errors (see patch 9.2.0006)
+            $cmd = $cat + " | & { " + $cmd + " } " + $redir
         }
 
         $ErrorActionPreference = "Stop"
@@ -84,7 +80,7 @@ try
     }
     else
     {
-        if ($cmdline -match "\((?<cmd>.*)(?<redir> >.*)\)$")
+        if ($cmdline -match "\((?<cmd>.*)(?<redir>>.*)\)$")
         {
             $cmd = $matches.cmd
             $redir = $matches.redir
@@ -98,8 +94,23 @@ try
             throw "unexpected cmdline: $cmdline"
         }
 
+        # trimming external parenthesis (interfere with pwsh redirection)
+        while ($cmd -match "\s*\((?<cmd>.*)\)\s*$")
+        {
+            $cmd = $matches.cmd
+        }
+
+        if ($redir)
+        {
+            # allow multiple expressions (see patch 9.2.0006)
+            # redirection prevents error propagation
+            $cmd = "& { `$ErrorActionPreference = 'Stop'; try { $cmd } catch { exit 1 }" 
+            $cmd += '; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }}'
+            $cmd += $redir
+        }
+
         # allow stdin forwarding under binary demand
-        $b64_cmd = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($cmd))
+        $b64_cmd = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($encoding + $cmd))
         & $pwsh_cmd $pwsh_arg -NoLogo -NoProfile -ExecutionPolicy Bypass -EncodedCommand $b64_cmd
     }
 

--- a/start/setpwsh/scripts/vim_pwsh_proxy.ps1
+++ b/start/setpwsh/scripts/vim_pwsh_proxy.ps1
@@ -53,19 +53,15 @@ try
                ForEach-Object { $res = $cmd } { $res = $res.Remove($_.Index, $_.Length) }
 
         $is_pipe = $res -match '\$_\b'
-        $is_input = $res -match '\$input\b'
+        # $is_input = $res -match '\$input\b'
 
         if ($is_pipe)
         { # execute expression per-line
             $cmd = $cat + " | % { " + $cmd + " } " + $redir
         }
-        elseif ($is_input)
-        { # use script object to enable $input
-            $cmd = $cat + " | & { " + $cmd + " } " + $redir
-        }
         else
-        { # send in bulk
-            $cmd = $cat + " | " + $cmd + " " + $redir
+        { # use script object to enable $input and avoid redirection errors (see patch 9.2.0006)
+            $cmd = $cat + " | & { " + $cmd + " } " + $redir
         }
 
         $ErrorActionPreference = "Stop"
@@ -95,6 +91,9 @@ try
 
         if ($redir)
         {
+            # allow multiple expressions (see patch 9.2.0006)
+            $cmd = "& { `$ErrorActionPreference = 'Stop'; try { $cmd } catch { exit 1 }" 
+            $cmd += '; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }}'
             $cmd += $redir
         }
 

--- a/start/setpwsh/scripts/vim_pwsh_proxy.ps1
+++ b/start/setpwsh/scripts/vim_pwsh_proxy.ps1
@@ -1,7 +1,7 @@
 # vim_pwsh_proxy.ps1
 # Expects:
 #   set shell=powershell (or set shell=pwsh)
-#   let &shellcmdflag="-NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File \"" . s:auxshellscriptname . '"' 
+#   let &shellcmdflag="-NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File \"" . s:auxshellscriptname . '"'
 #   set shellquote=
 #   set shellxquote=(
 #   set shellredir=>%s
@@ -24,9 +24,9 @@ try
         }
     }
 
-    $encoding += '[Console]::InputEncoding = $OutputEncoding;' 
-    $encoding += '[Console]::OutputEncoding = $OutputEncoding;' 
-    $encoding += '$PSDefaultParameterValues["*:Encoding"] = "{0}";' -f $Env:setpwsh_encoding 
+    $encoding += '[Console]::InputEncoding = $OutputEncoding;'
+    $encoding += '[Console]::OutputEncoding = $OutputEncoding;'
+    $encoding += '$PSDefaultParameterValues["*:Encoding"] = "{0}";' -f $Env:setpwsh_encoding
 
     Invoke-Expression -Command $encoding
 
@@ -53,15 +53,19 @@ try
                ForEach-Object { $res = $cmd } { $res = $res.Remove($_.Index, $_.Length) }
 
         $is_pipe = $res -match '\$_\b'
-        # $is_input = $res -match '\$input\b'
+        $is_input = $res -match '\$input\b'
 
         if ($is_pipe)
         { # execute expression per-line
             $cmd = $cat + " | % { " + $cmd + " } " + $redir
         }
+        elseif ($is_input)
+        {
+            $cmd = $cat + " | & { " + $cmd + " } " + $redir
+        }
         else
         { # use script object to enable $input and avoid redirection errors (see patch 9.2.0006)
-            $cmd = $cat + " | & { " + $cmd + " } " + $redir
+            $cmd = $cat + " | & { `$input | " + $cmd + " } " + $redir
         }
 
         $ErrorActionPreference = "Stop"
@@ -69,7 +73,7 @@ try
     }
     else
     {
-        if ($cmdline -match "\((?<cmd>.*)(?<redir> >.*)\)$")
+        if ($cmdline -match "\(& {(?<cmd>.*)}(?<redir> >.*)\)$")
         {
             $cmd = $matches.cmd
             $redir = $matches.redir
@@ -92,6 +96,7 @@ try
         if ($redir)
         {
             # allow multiple expressions (see patch 9.2.0006)
+            # redirection prevents error propagation
             $cmd = "& { `$ErrorActionPreference = 'Stop'; try { $cmd } catch { exit 1 }" 
             $cmd += '; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }}'
             $cmd += $redir
@@ -101,7 +106,6 @@ try
         $b64_cmd = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($encoding + $cmd))
         & $proc.ProcessName -NoLogo -NoProfile -ExecutionPolicy Bypass `
                             -NonInteractive -EncodedCommand $b64_cmd
-
     }
 
     # Unlike powershell core, BOM emission on redirection cannot be disabled for Desktop edition.
@@ -123,7 +127,7 @@ try
                 $content | Select-Object -Skip $Length |
                     Set-Content -Path $file -Encoding Byte
             }
-        }         
+        }
     }
 
     # propagate error level

--- a/start/setpwsh/tests/test_plugin_setpwsh.vim
+++ b/start/setpwsh/tests/test_plugin_setpwsh.vim
@@ -20,7 +20,7 @@ endfunc
 " After each test remove the plugin
 func TearDown()
 
-    " Unload the plugin 
+    " Unload the plugin
     let globals = [
                 \ 'g:loaded_setpwsh',
                 \ 'g:setpwsh_shell',
@@ -261,6 +261,25 @@ func s:bang_tests(shellname)
         let output = split(trim(output), '\r\n')
         call assert_equal(gref , output[0:4], a:shellname)
     endif
+
+    " Check using multiple expressions
+    enew!
+    const mref = ['123', '456']
+
+    if has("gui_running")
+        redir => output
+        exe "normal :!echo 123; echo 456\<CR>\<CR>"
+        redir END
+
+        " let output = split(output, "\<CR>\<LF>")
+        let output = split(output, '\r\n')
+        call assert_equal(mref, output[1:2], a:shellname)
+    endif
+
+    " Check read from multiple expressions
+    read !echo 123; echo 456
+    call assert_equal(mref, getline(2, 3), a:shellname)
+
 endfunc
 
 "system() testing helper function. Precondition: plugin already loaded
@@ -281,13 +300,13 @@ func s:system_tests(shellname)
     let output = split(output)
     call assert_equal(ref , output, a:shellname)
 
-    let output = system('% { "-->$_<--" }', "vim") 
+    let output = system('% { "-->$_<--" }', "vim")
     if a:shellname ==# "Desktop" && has("gui_running")
         let output = s:remove_bom(output)
     endif
     call assert_equal("-->vim<--" , trim(output), a:shellname)
 
-    let output = system('% { "-->$_<--" }', ref) 
+    let output = system('% { "-->$_<--" }', ref)
     if a:shellname ==# "Desktop" && has("gui_running")
         let output = s:remove_bom(output)
     endif
@@ -299,12 +318,20 @@ func s:system_tests(shellname)
 "   " Check systemlist()
 "   let output = systemlist("1..5 | % {[char]($_+96)}")
 "   call assert_equal(ref , output, "powershell")
- 
+
     " Backtick execution is a particular case of system()
     " open this very file
     let this_script = expand("<script>")
     exe $"view `(Get-Item -Path {this_script}).FullName`"
     call assert_equal(bufnr(''), bufnr(this_script), a:shellname)
+
+    " Check using multiple expressions
+    let output = system("echo 123; echo 456")
+    if a:shellname ==# "Desktop" && has("gui_running")
+        let output = s:remove_bom(output)
+    endif
+    let output = split(output)
+    call assert_equal(['123', '456'] , output, a:shellname)
 
 endfunc
 
@@ -407,7 +434,7 @@ func s:shell_error_tests(shellname)
 
     call system($"Get-Item -Path {this_script}")
     call assert_equal(0, v:shell_error, a:shellname)
- 
+
     " Errors on bang commands
     " Check error on unknown command
     exe "normal :!unknown-command\<CR>\<CR>"


### PR DESCRIPTION
The [patch 9.2.0006](https://github.com/neovim/neovim/pull/37888) modifies the shell command line composition for powershell. The plugin parsing must be updated accordingly.
Backward compatibility is preserved.